### PR TITLE
fix: apply 30% ruling to full gross when holiday allowance included

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -113,3 +113,51 @@ describe('Tax calculation section', () => {
     });
   });
 });
+
+describe('30% ruling with holiday allowance included', () => {
+  test('should apply 30% ruling on full gross including holiday allowance', () => {
+    const result = new SalaryPaycheck(
+      { income: 100000, allowance: true, socialSecurity: true, older: false, hours: 40 },
+      'Year',
+      2026,
+      { checked: true, choice: 'normal' }
+    );
+
+    expect(result.taxableYear).toBeCloseTo(70000, 0);
+    expect(result.taxFreeYear).toBeCloseTo(30000, 0);
+    expect(result.taxFree).toBeCloseTo(30, 0);
+  });
+
+  test('should produce consistent results with and without allowance flag', () => {
+    const withAllowance = new SalaryPaycheck(
+      { income: 108000, allowance: true, socialSecurity: true, older: false, hours: 40 },
+      'Year',
+      2026,
+      { checked: true, choice: 'normal' }
+    );
+
+    const withoutAllowance = new SalaryPaycheck(
+      { income: 100000, allowance: false, socialSecurity: true, older: false, hours: 40 },
+      'Year',
+      2026,
+      { checked: true, choice: 'normal' }
+    );
+
+    // 108000 with allowance has same base salary (100000) as 100000 without allowance
+    // Both should show 30% tax-free
+    expect(withAllowance.taxFree).toBeCloseTo(30, 0);
+    expect(withoutAllowance.taxFree).toBeCloseTo(30, 0);
+  });
+
+  test('should not apply ruling when allowance=false and ruling unchecked', () => {
+    const result = new SalaryPaycheck(
+      { income: 100000, allowance: false, socialSecurity: true, older: false, hours: 40 },
+      'Year',
+      2026,
+      { checked: false }
+    );
+
+    expect(result.taxFreeYear).toBe(0);
+    expect(result.taxableYear).toBe(100000);
+  });
+});

--- a/index.js
+++ b/index.js
@@ -46,16 +46,16 @@ class SalaryPaycheck {
     if (ruling.checked) {
       let rulingIncome = SalaryPaycheck.getRulingIncome(year, ruling.choice);
       let rulingMaxSalary = constants.rulingMaxSalary[year];
-      // 30% ruling only up to the salary cap
-      let salaryEligibleForRuling = Math.min(this.taxableYear, rulingMaxSalary);
-      let salaryAboveCap = Math.max(0, this.taxableYear - rulingMaxSalary);
+      // 30% ruling applies to full gross (including holiday allowance)
+      let salaryEligibleForRuling = Math.min(grossYear, rulingMaxSalary);
+      let salaryAboveCap = Math.max(0, grossYear - rulingMaxSalary);
       // Calculate the 30% on eligible salary only
       let effectiveSalary = salaryEligibleForRuling * 0.7 + salaryAboveCap;
       effectiveSalary = Math.max(effectiveSalary, rulingIncome);
-      let reimbursement = this.taxableYear - effectiveSalary;
+      let reimbursement = grossYear - effectiveSalary;
       if (reimbursement > 0) {
         this.taxFreeYear = reimbursement;
-        this.taxableYear = this.taxableYear - reimbursement;
+        this.taxableYear = grossYear - reimbursement;
       }
     }
 


### PR DESCRIPTION
## Summary

- **Bug**: When `allowance=true` (holiday pay included in gross) and the 30% ruling was active, the ruling was applied to `grossYear - holidayAllowance` instead of the full `grossYear`. This resulted in a lower tax-free amount and incorrect net salary.
- **Fix**: Changed the ruling block in `index.js` to use `grossYear` as the base, matching Belastingdienst rules that the 30% ruling applies to total employment income including holiday allowance.
- **Tests**: Added 3 test cases covering the `allowance=true` + ruling combination, which was previously untested.

### Example (100k gross, allowance included, 30% ruling)

| | Before (bug) | After (fix) |
|---|---|---|
| taxableYear | 64,815 | 70,000 |
| taxFreeYear | 27,778 | 30,000 |
| taxFree % | 27.78% | 30% |

## Test plan

- [x] All 13 existing tax table tests pass
- [x] New test: 30% ruling applied to full gross with holiday allowance
- [x] New test: consistency between allowance=true and allowance=false
- [x] New test: no regression when ruling is unchecked

🤖 Generated with [Claude Code](https://claude.com/claude-code)