### PR TITLE
fix: add 8% holiday allowance to gross when 30% ruling applied without allowance

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -161,3 +161,72 @@ describe('30% ruling with holiday allowance included', () => {
     expect(result.taxableYear).toBe(100000);
   });
 });
+
+describe('30% ruling without holiday allowance (allowance=false)', () => {
+  test('should add 8% holiday allowance to gross when ruling is applied', () => {
+    const result = new SalaryPaycheck(
+      { income: 100000, allowance: false, socialSecurity: true, older: false, hours: 40 },
+      'Year',
+      2026,
+      { checked: true, choice: 'normal' }
+    );
+
+    // Gross should be inflated by 8% to reflect total employment income
+    expect(result.grossYear).toBe(108000);
+    expect(result.grossAllowance).toBeCloseTo(8000, 0);
+  });
+
+  test('should produce identical results for equivalent salaries with and without allowance', () => {
+    const withAllowance = new SalaryPaycheck(
+      { income: 108000, allowance: true, socialSecurity: true, older: false, hours: 40 },
+      'Year',
+      2026,
+      { checked: true, choice: 'normal' }
+    );
+
+    const withoutAllowance = new SalaryPaycheck(
+      { income: 100000, allowance: false, socialSecurity: true, older: false, hours: 40 },
+      'Year',
+      2026,
+      { checked: true, choice: 'normal' }
+    );
+
+    expect(withoutAllowance.grossYear).toBe(withAllowance.grossYear);
+    expect(withoutAllowance.taxFreeYear).toBe(withAllowance.taxFreeYear);
+    expect(withoutAllowance.taxableYear).toBe(withAllowance.taxableYear);
+    expect(withoutAllowance.incomeTax).toBe(withAllowance.incomeTax);
+    expect(withoutAllowance.netYear).toBe(withAllowance.netYear);
+    expect(withoutAllowance.netMonth).toBe(withAllowance.netMonth);
+  });
+
+  test('should not inflate gross when ruling is unchecked', () => {
+    const result = new SalaryPaycheck(
+      { income: 100000, allowance: false, socialSecurity: true, older: false, hours: 40 },
+      'Year',
+      2026,
+      { checked: false }
+    );
+
+    expect(result.grossYear).toBe(100000);
+    expect(result.grossAllowance).toBe(0);
+  });
+
+  test('should work correctly with monthly input', () => {
+    const monthly = new SalaryPaycheck(
+      { income: 5000, allowance: false, socialSecurity: true, older: false, hours: 40 },
+      'Month',
+      2026,
+      { checked: true, choice: 'normal' }
+    );
+
+    const yearlyEquivalent = new SalaryPaycheck(
+      { income: 5000 * 12 * 1.08, allowance: true, socialSecurity: true, older: false, hours: 40 },
+      'Year',
+      2026,
+      { checked: true, choice: 'normal' }
+    );
+
+    expect(monthly.grossYear).toBeCloseTo(yearlyEquivalent.grossYear, 0);
+    expect(monthly.netYear).toBeCloseTo(yearlyEquivalent.netYear, 0);
+  });
+});

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -174,6 +174,8 @@ describe('30% ruling without holiday allowance (allowance=false)', () => {
     // Gross should be inflated by 8% to reflect total employment income
     expect(result.grossYear).toBe(108000);
     expect(result.grossAllowance).toBeCloseTo(8000, 0);
+    // Original input preserved
+    expect(result.inputGrossYear).toBe(100000);
   });
 
   test('should produce identical results for equivalent salaries with and without allowance', () => {
@@ -208,6 +210,7 @@ describe('30% ruling without holiday allowance (allowance=false)', () => {
     );
 
     expect(result.grossYear).toBe(100000);
+    expect(result.inputGrossYear).toBe(100000);
     expect(result.grossAllowance).toBe(0);
   });
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ class SalaryPaycheck {
    * @returns {object} Object with all calculated fields for the salary paycheck
    */
   constructor(salaryInput, startFrom, year, ruling) {
-    const { income, allowance, socialSecurity, older, hours } = salaryInput;
+    let { income, allowance, socialSecurity, older, hours } = salaryInput;
     this.grossYear =
       this.grossMonth =
       this.grossWeek =
@@ -29,6 +29,13 @@ class SalaryPaycheck {
       this.grossHour * constants.workingWeeks * hours;
     if (!grossYear || grossYear < 0) {
       grossYear = 0;
+    }
+
+    // When salary doesn't include holiday allowance but 30% ruling is applied,
+    // add 8% to get total employment income (ruling applies to total comp)
+    if (!allowance && ruling.checked) {
+      grossYear = roundNumber(grossYear * 1.08, 2);
+      allowance = true;
     }
 
     this.grossAllowance = allowance

--- a/index.js
+++ b/index.js
@@ -31,6 +31,9 @@ class SalaryPaycheck {
       grossYear = 0;
     }
 
+    // Store the original input before any adjustments
+    this.inputGrossYear = roundNumber(grossYear, 2);
+
     // When salary doesn't include holiday allowance but 30% ruling is applied,
     // add 8% to get total employment income (ruling applies to total comp)
     if (!allowance && ruling.checked) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -122,6 +122,7 @@ export class SalaryPaycheck {
     year: number,
     ruling: RulingInput
   );
+  inputGrossYear: number;
   grossYear: number;
   grossMonth: number;
   grossWeek: number;


### PR DESCRIPTION
## Summary
- When salary is entered without holiday allowance (`allowance=false`) and the 30% ruling is active, the gross was missing the 8% holiday component, causing incorrect net salary calculations
- The fix inflates `grossYear` by 8% and enables the allowance flag when ruling is checked, so both input paths (with/without allowance) produce identical results for equivalent salaries
- No-ruling calculations are completely unaffected

Follows up on #50 — that fix covered the `allowance=true` case; this covers the opposite `allowance=false` scenario.

## Test plan
- [x] Existing 16 tests still pass (including tax table validation for all years)
- [x] Added test: gross gets inflated by 8% when ruling is applied with `allowance=false`
- [x] Added test: 100k without allowance produces identical results to 108k with allowance (both + ruling)
- [x] Added test: gross is NOT inflated when ruling is unchecked
- [x] Added test: works correctly with monthly input

🤖 Generated with [Claude Code](https://claude.com/claude-code)