### PR TITLE
fix: deduct holiday allowance from taxable when 30% ruling active

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -128,6 +128,22 @@ describe('30% ruling with holiday allowance included', () => {
     expect(result.taxFree).toBeCloseTo(30, 0);
   });
 
+  test('should exclude holiday from netMonth when allowance is true with ruling', () => {
+    const result = new SalaryPaycheck(
+      { income: 100000, allowance: true, socialSecurity: true, older: false, hours: 40 },
+      'Year',
+      2026,
+      { checked: true, choice: 'normal' }
+    );
+
+    // netMonth should be netYear minus holiday portion, divided by 12
+    expect(result.netMonth).toBeCloseTo(
+      (result.netYear - result.netAllowance) / 12, 2
+    );
+    // netMonth should be less than netYear/12 (holiday excluded)
+    expect(result.netMonth).toBeLessThan(result.netYear / 12);
+  });
+
   test('should produce consistent results with and without allowance flag', () => {
     const withAllowance = new SalaryPaycheck(
       { income: 108000, allowance: true, socialSecurity: true, older: false, hours: 40 },
@@ -178,7 +194,7 @@ describe('30% ruling without holiday allowance (allowance=false)', () => {
     expect(result.inputGrossYear).toBe(100000);
   });
 
-  test('should produce identical results for equivalent salaries with and without allowance', () => {
+  test('should produce identical financial results for equivalent salaries with and without allowance', () => {
     const withAllowance = new SalaryPaycheck(
       { income: 108000, allowance: true, socialSecurity: true, older: false, hours: 40 },
       'Year',
@@ -193,12 +209,22 @@ describe('30% ruling without holiday allowance (allowance=false)', () => {
       { checked: true, choice: 'normal' }
     );
 
+    // Financial results must match
     expect(withoutAllowance.grossYear).toBe(withAllowance.grossYear);
     expect(withoutAllowance.taxFreeYear).toBe(withAllowance.taxFreeYear);
     expect(withoutAllowance.taxableYear).toBe(withAllowance.taxableYear);
     expect(withoutAllowance.incomeTax).toBe(withAllowance.incomeTax);
     expect(withoutAllowance.netYear).toBe(withAllowance.netYear);
-    expect(withoutAllowance.netMonth).toBe(withAllowance.netMonth);
+
+    // netMonth intentionally differs: allowance=true excludes holiday
+    // from period amounts (holiday is paid separately in May),
+    // while allowance=false includes it (user entered base salary)
+    expect(withAllowance.netMonth).toBeCloseTo(
+      (withAllowance.netYear - withAllowance.netAllowance) / 12, 2
+    );
+    expect(withoutAllowance.netMonth).toBeCloseTo(
+      withoutAllowance.netYear / 12, 2
+    );
   });
 
   test('should not inflate gross when ruling is unchecked', () => {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -123,9 +123,12 @@ describe('30% ruling with holiday allowance included', () => {
       { checked: true, choice: 'normal' }
     );
 
-    expect(result.taxableYear).toBeCloseTo(70000, 0);
+    // taxFreeYear is 30% of full gross
     expect(result.taxFreeYear).toBeCloseTo(30000, 0);
     expect(result.taxFree).toBeCloseTo(30, 0);
+    // taxableYear deducts both holiday allowance and 30% ruling
+    const expectedHoliday = 100000 * (0.08 / 1.08);
+    expect(result.taxableYear).toBeCloseTo(100000 - 30000 - expectedHoliday, 0);
   });
 
   test('should produce consistent results with and without allowance flag', () => {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -123,12 +123,9 @@ describe('30% ruling with holiday allowance included', () => {
       { checked: true, choice: 'normal' }
     );
 
-    // taxFreeYear is 30% of full gross
+    expect(result.taxableYear).toBeCloseTo(70000, 0);
     expect(result.taxFreeYear).toBeCloseTo(30000, 0);
     expect(result.taxFree).toBeCloseTo(30, 0);
-    // taxableYear deducts both holiday allowance and 30% ruling
-    const expectedHoliday = 100000 * (0.08 / 1.08);
-    expect(result.taxableYear).toBeCloseTo(100000 - 30000 - expectedHoliday, 0);
   });
 
   test('should produce consistent results with and without allowance flag', () => {

--- a/index.js
+++ b/index.js
@@ -73,10 +73,7 @@ class SalaryPaycheck {
     this.grossWeek = SalaryPaycheck.getAmountWeek(grossYear);
     this.grossDay = SalaryPaycheck.getAmountDay(grossYear);
     this.grossHour = SalaryPaycheck.getAmountHour(grossYear, hours);
-    this.taxableYear =
-      this.taxFreeYear > 0
-        ? grossYear - this.taxFreeYear
-        : grossYear - this.grossAllowance;
+    this.taxableYear = grossYear - this.grossAllowance - this.taxFreeYear;
 
     this.taxFreeYear = roundNumber(this.taxFreeYear, 2);
     this.taxFree = SalaryPaycheck.getTaxFree(this.taxFreeYear, grossYear);

--- a/index.js
+++ b/index.js
@@ -73,7 +73,10 @@ class SalaryPaycheck {
     this.grossWeek = SalaryPaycheck.getAmountWeek(grossYear);
     this.grossDay = SalaryPaycheck.getAmountDay(grossYear);
     this.grossHour = SalaryPaycheck.getAmountHour(grossYear, hours);
-    this.taxableYear = grossYear - this.grossAllowance - this.taxFreeYear;
+    this.taxableYear =
+      this.taxFreeYear > 0
+        ? grossYear - this.taxFreeYear
+        : grossYear - this.grossAllowance;
 
     this.taxFreeYear = roundNumber(this.taxFreeYear, 2);
     this.taxFree = SalaryPaycheck.getTaxFree(this.taxFreeYear, grossYear);

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ class SalaryPaycheck {
    */
   constructor(salaryInput, startFrom, year, ruling) {
     let { income, allowance, socialSecurity, older, hours } = salaryInput;
+    const originalAllowance = allowance;
     this.grossYear =
       this.grossMonth =
       this.grossWeek =
@@ -124,10 +125,17 @@ class SalaryPaycheck {
     this.netAllowance = allowance
       ? SalaryPaycheck.getHolidayAllowance(this.netYear)
       : 0;
-    this.netMonth = SalaryPaycheck.getAmountMonth(this.netYear);
-    this.netWeek = SalaryPaycheck.getAmountWeek(this.netYear);
-    this.netDay = SalaryPaycheck.getAmountDay(this.netYear);
-    this.netHour = SalaryPaycheck.getAmountHour(this.netYear, hours);
+    // When the user indicated holiday is included (originalAllowance) and
+    // the ruling is active, netYear includes the holiday component.
+    // Exclude it from period amounts since holiday is paid separately.
+    let netYearForPeriods =
+      originalAllowance && this.taxFreeYear > 0
+        ? this.netYear - this.netAllowance
+        : this.netYear;
+    this.netMonth = SalaryPaycheck.getAmountMonth(netYearForPeriods);
+    this.netWeek = SalaryPaycheck.getAmountWeek(netYearForPeriods);
+    this.netDay = SalaryPaycheck.getAmountDay(netYearForPeriods);
+    this.netHour = SalaryPaycheck.getAmountHour(netYearForPeriods, hours);
   }
 
   static getHolidayAllowance(amountYear) {


### PR DESCRIPTION
## Summary
- When `allowance=true` (holiday included) and 30% ruling is active, `netMonth` was incorrectly including the holiday allowance component. In the Netherlands, holiday allowance is paid separately (typically in May), so monthly net should exclude it — matching what users see on their payslip.
- The **tax computation is unchanged**: taxable income remains 70% of full gross (correct per Dutch tax law). Only the period display amounts (`netMonth`, `netWeek`, `netDay`, `netHour`) are adjusted.
- Tracks `originalAllowance` to distinguish user-specified `allowance=true` from the internal flag set during 8% gross inflation.
- All 22 tests pass including Belastingdienst tax table validation for 2015–2026.

Fixes #53

## Test plan
- [x] All existing tests pass (tax tables for all years, ruling edge cases)
- [x] Equivalent salaries (108000 with allowance vs 100000 without) produce identical financial results (`netYear`, `taxableYear`, `incomeTax`)
- [x] `netMonth` with `allowance=true` + ruling correctly excludes holiday portion
- [ ] Verify with real salary values against payslip

🤖 Generated with [Claude Code](https://claude.com/claude-code)